### PR TITLE
move label for median value

### DIFF
--- a/js/quartiles-chart.js
+++ b/js/quartiles-chart.js
@@ -74,7 +74,8 @@ function quartilesChart() {
           })
           .style('alignment-baseline', 'before-edge')
           .attr("transform", function(d,i){
-            return "translate(" + x(d) + "," + y(0) + ")"
+            if (i === 2) { return "translate(" + x(d) + "," + y(0.15) + ")"}
+            else { return "translate(" + x(d) + "," + y(0) + ")" }
           })
           .text(function(d,i){
             var val = d


### PR DESCRIPTION
so it doesn't overlap 3rd quartile label.
fixes #80 
<img width="631" alt="screen shot 2017-08-03 at 1 21 12 pm" src="https://user-images.githubusercontent.com/4649503/28942002-add50bda-784e-11e7-9eca-165f4f323736.png">
<img width="624" alt="screen shot 2017-08-03 at 1 21 21 pm" src="https://user-images.githubusercontent.com/4649503/28942001-add2f82c-784e-11e7-97e5-e8b23e6aac48.png">
